### PR TITLE
Add CMake options for building tests and finding Catch

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build dragon and run tests
         run: |
           mkdir build; cd build
-          cmake ../
+          cmake ../ -DDRAGON_BUILD_TESTS=ON
           make
           ctest -j4
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,18 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(dragon
-        VERSION 1.0.0
+        VERSION 0.1.0
         LANGUAGES C CXX)
 
-enable_testing()
-
-find_package(Catch2 REQUIRED)
+option(DRAGON_BUILD_TESTS "Build test files" OFF)
+STRING(CONCAT CATCH_PATH_HELP "Path to Catch2 installation, required when "
+                              "catch2 is installed in a non-default path")
+option(CATCH_PATH ${CATCH_PATH_HELP})
 
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
-add_subdirectory(${CMAKE_SOURCE_DIR}/tests)
+if (DRAGON_BUILD_TESTS)
+  include(CTest)
+  enable_testing()
+  add_subdirectory(${CMAKE_SOURCE_DIR}/tests)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
+find_package(Catch2 REQUIRED PATHS ${CATCH_PATH})
 add_library(main OBJECT main.cpp)
-
 include(Catch)
 
 set(items algos core ds graph number-theory sorting tree)


### PR DESCRIPTION
This PR adds two new CMake options.

- `BUILD_TESTS`: If this option is `ON` then tests are built and can be run using `ctest` in the build directory, default to OFF
- `CATCH_PATH`: Path to find `catch2`. It should be used if `catch2` is installed in a non-default path.
